### PR TITLE
Fix support for new S3 Buckets

### DIFF
--- a/lambda/Makefile
+++ b/lambda/Makefile
@@ -41,8 +41,7 @@ clean:
 	rm -f ._*
 
 ._%: %.zip
-	"$(AWSCMD)" $(AWSARGS) s3 cp "$<" "s3://$(S3DEST)" \
-		--grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+	"$(AWSCMD)" $(AWSARGS) s3 cp "$<" "s3://$(S3DEST)"
 	cp "$<" "$@"
 
 # This rule is a BSD make style rule that says "to make foo.zip, call


### PR DESCRIPTION
Newly created S3 buckets don't support ACLs. The rest of this works fine without the ACL steps.

## Related
https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/